### PR TITLE
fix: harden root login notification (error handling, null safety, CRLF defense-in-depth)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,24 @@
             <version>3.4.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/org/jahia/modules/rootloginnotification/RootLoginListener.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/RootLoginListener.java
@@ -2,11 +2,15 @@ package org.jahia.modules.rootloginnotification;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jahia.params.valves.AuthValveContext;
 import org.jahia.params.valves.BaseLoginEvent;
 import org.jahia.services.mail.MailService;
 import org.jahia.services.observation.JahiaEventListener;
+import org.jahia.services.usermanager.JahiaUser;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.http.HttpServletRequest;
 import java.time.Instant;
@@ -18,57 +22,101 @@ import java.util.regex.Pattern;
 @Component(immediate = true, service = JahiaEventListener.class)
 public final class RootLoginListener implements JahiaEventListener<BaseLoginEvent> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RootLoginListener.class);
+
     private static final String REMOTE_ADDRESS_HEADER = "x-forwarded-for";
+    private static final String DEFAULT_SITE = "systemsite";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter
             .ofPattern("yyyy/MM/dd 'at' HH:mm:ss z")
             .withZone(ZoneId.systemDefault());
     private static final Class<BaseLoginEvent>[] ALLOWED_EVENT_TYPES = new Class[]{BaseLoginEvent.class};
     // Conservative pattern: IPv4, IPv6 hex+colons, hostnames. Strips anything else.
     private static final Pattern SAFE_HOST_CHARS = Pattern.compile("[^A-Za-z0-9._:\\-]");
+    // Characters legitimately found in an email address; everything else (incl. CR/LF) is stripped.
+    private static final Pattern SAFE_ADDRESS_CHARS = Pattern.compile("[^A-Za-z0-9._%+\\-@]");
     private static final int MAX_HEADER_VALUE_LENGTH = 255;
+    private static final char DEL_CHAR = 0x7F;
+    private static final char FIRST_PRINTABLE_CHAR = 0x20;
 
     private MailService mailService;
     private RootLoginNotificationConfig config;
 
     @Override
     public void onEvent(EventObject event) {
-        final BaseLoginEvent baseLoginEvent = (BaseLoginEvent) event;
-        if (mailService.isEnabled() && baseLoginEvent.getJahiaUser().isRoot()) {
-            final HttpServletRequest request = baseLoginEvent.getAuthValveContext().getRequest();
-            String remoteAddress = request.getHeader(REMOTE_ADDRESS_HEADER);
-            if (remoteAddress == null) {
-                remoteAddress = request.getRemoteAddr();
-            }
-            // x-forwarded-for may contain a comma-separated chain; keep only the first entry (the client).
-            if (remoteAddress != null) {
-                final int comma = remoteAddress.indexOf(',');
-                if (comma >= 0) {
-                    remoteAddress = remoteAddress.substring(0, comma);
-                }
-            }
-            // Sanitize user-controlled values inserted into mail subject/body to prevent header
-            // injection (CRLF) and XSS in the HTML body.
-            remoteAddress = sanitizeHost(remoteAddress);
-
-            String site = request.getParameter("site");
-            if (StringUtils.isEmpty(site)) {
-                site = "systemsite";
-            }
-            site = sanitizeHeader(site);
-            final String serverName = sanitizeHost(request.getServerName());
-            final String loginTime = DATE_FORMATTER.format(Instant.ofEpochMilli(baseLoginEvent.getTimestamp()));
-
-            final String sender = StringUtils.defaultIfEmpty(config.getSender(), mailService.defaultSender());
-            final String recipient = StringUtils.defaultIfEmpty(config.getRecipient(), mailService.defaultRecipient());
-            final String subject = config.getSubject()
-                    .replace("{server}", serverName)
-                    .replace("{site}", site);
-            final String body = config.getBody()
-                    .replace("{ip}", StringEscapeUtils.escapeHtml(remoteAddress))
-                    .replace("{time}", StringEscapeUtils.escapeHtml(loginTime));
-
-            mailService.sendMessage(sender, recipient, null, null, subject, null, body);
+        // A notification failure must never break the login flow: catch everything, log it, move on.
+        try {
+            handleLoginEvent(event);
+        } catch (RuntimeException e) {
+            LOGGER.error("Failed to send root login notification email", e);
         }
+    }
+
+    private void handleLoginEvent(EventObject event) {
+        if (!(event instanceof BaseLoginEvent)) {
+            return;
+        }
+        final BaseLoginEvent baseLoginEvent = (BaseLoginEvent) event;
+
+        if (mailService == null || config == null || !mailService.isEnabled()) {
+            return;
+        }
+
+        final JahiaUser user = baseLoginEvent.getJahiaUser();
+        if (user == null || !user.isRoot()) {
+            return;
+        }
+
+        final AuthValveContext valveContext = baseLoginEvent.getAuthValveContext();
+        final HttpServletRequest request = (valveContext != null) ? valveContext.getRequest() : null;
+
+        final String remoteAddress = sanitizeHost(resolveRemoteAddress(request));
+        final String site = sanitizeHeader(resolveSite(request));
+        final String serverName = sanitizeHost(request != null ? request.getServerName() : null);
+        final String loginTime = DATE_FORMATTER.format(Instant.ofEpochMilli(baseLoginEvent.getTimestamp()));
+
+        // recipient/sender may come from the OSGi .cfg file directly (bypassing the GraphQL
+        // email-format validation), so sanitize CR/LF here as a header-injection defense.
+        final String sender = sanitizeAddress(StringUtils.defaultIfEmpty(config.getSender(), mailService.defaultSender()));
+        final String recipient = sanitizeAddress(StringUtils.defaultIfEmpty(config.getRecipient(), mailService.defaultRecipient()));
+
+        // The subject is an email header; sanitize the fully-assembled value for CR/LF, since the
+        // subject template itself (from config) is also user-controlled.
+        final String subject = sanitizeHeader(StringUtils.defaultString(config.getSubject())
+                .replace("{server}", serverName)
+                .replace("{site}", site));
+        final String body = StringUtils.defaultString(config.getBody())
+                .replace("{ip}", StringEscapeUtils.escapeHtml(remoteAddress))
+                .replace("{time}", StringEscapeUtils.escapeHtml(loginTime));
+
+        if (StringUtils.isEmpty(recipient)) {
+            LOGGER.warn("Root login notification skipped: no recipient configured and no MailService default available");
+            return;
+        }
+
+        mailService.sendMessage(sender, recipient, null, null, subject, null, body);
+    }
+
+    private static String resolveRemoteAddress(HttpServletRequest request) {
+        if (request == null) {
+            return "";
+        }
+        String remoteAddress = request.getHeader(REMOTE_ADDRESS_HEADER);
+        if (remoteAddress == null) {
+            remoteAddress = request.getRemoteAddr();
+        }
+        // x-forwarded-for may contain a comma-separated chain; keep only the first entry (the client).
+        if (remoteAddress != null) {
+            final int comma = remoteAddress.indexOf(',');
+            if (comma >= 0) {
+                remoteAddress = remoteAddress.substring(0, comma);
+            }
+        }
+        return remoteAddress;
+    }
+
+    private static String resolveSite(HttpServletRequest request) {
+        final String site = (request != null) ? request.getParameter("site") : null;
+        return StringUtils.isEmpty(site) ? DEFAULT_SITE : site;
     }
 
     /** Strips anything that is not a valid host/IP character to prevent header injection and XSS. */
@@ -80,6 +128,15 @@ public final class RootLoginListener implements JahiaEventListener<BaseLoginEven
         return SAFE_HOST_CHARS.matcher(trimmed).replaceAll("");
     }
 
+    /** Strips anything that is not a valid email-address character, removing CR/LF header-injection vectors. */
+    private static String sanitizeAddress(String value) {
+        if (value == null) {
+            return "";
+        }
+        final String trimmed = StringUtils.left(value, MAX_HEADER_VALUE_LENGTH);
+        return SAFE_ADDRESS_CHARS.matcher(trimmed).replaceAll("");
+    }
+
     /** Removes CR/LF and other control characters that could be used for header injection. */
     private static String sanitizeHeader(String value) {
         if (value == null) {
@@ -89,13 +146,12 @@ public final class RootLoginListener implements JahiaEventListener<BaseLoginEven
         final StringBuilder sb = new StringBuilder(trimmed.length());
         for (int i = 0; i < trimmed.length(); i++) {
             final char c = trimmed.charAt(i);
-            if (c >= 0x20 && c != 0x7F) {
+            if (c >= FIRST_PRINTABLE_CHAR && c != DEL_CHAR) {
                 sb.append(c);
             }
         }
         return sb.toString();
     }
-
 
     @Override
     public Class<BaseLoginEvent>[] getEventTypes() {

--- a/src/test/java/org/jahia/modules/rootloginnotification/RootLoginListenerTest.java
+++ b/src/test/java/org/jahia/modules/rootloginnotification/RootLoginListenerTest.java
@@ -1,0 +1,198 @@
+package org.jahia.modules.rootloginnotification;
+
+import org.jahia.params.valves.AuthValveContext;
+import org.jahia.params.valves.BaseLoginEvent;
+import org.jahia.services.mail.MailService;
+import org.jahia.services.usermanager.JahiaUser;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RootLoginListenerTest {
+
+    private MailService mailService;
+    private RootLoginNotificationConfig config;
+    private RootLoginListener listener;
+
+    @Before
+    public void setUp() {
+        mailService = mock(MailService.class);
+        config = mock(RootLoginNotificationConfig.class);
+        listener = new RootLoginListener();
+        listener.setMailService(mailService);
+        listener.setConfig(config);
+
+        when(mailService.isEnabled()).thenReturn(true);
+        when(mailService.defaultSender()).thenReturn("noreply@example.com");
+        when(mailService.defaultRecipient()).thenReturn("security@example.com");
+        when(config.getSubject()).thenReturn("[{server} - {site}] root login");
+        when(config.getBody()).thenReturn("IP: {ip} at {time}");
+    }
+
+    private BaseLoginEvent rootEvent(HttpServletRequest request) {
+        BaseLoginEvent event = mock(BaseLoginEvent.class);
+        JahiaUser user = mock(JahiaUser.class);
+        when(user.isRoot()).thenReturn(true);
+        AuthValveContext ctx = mock(AuthValveContext.class);
+        when(event.getJahiaUser()).thenReturn(user);
+        when(event.getAuthValveContext()).thenReturn(ctx);
+        // getTimestamp() is final on Spring's ApplicationEvent — cannot be stubbed; mock returns 0L.
+        when(ctx.getRequest()).thenReturn(request);
+        return event;
+    }
+
+    private HttpServletRequest request(String xff, String remoteAddr, String server, String site) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader("x-forwarded-for")).thenReturn(xff);
+        when(request.getRemoteAddr()).thenReturn(remoteAddr);
+        when(request.getServerName()).thenReturn(server);
+        when(request.getParameter("site")).thenReturn(site);
+        return request;
+    }
+
+    private String sentSubject() {
+        ArgumentCaptor<String> c = ArgumentCaptor.forClass(String.class);
+        verify(mailService).sendMessage(any(), any(), any(), any(), c.capture(), any(), any());
+        return c.getValue();
+    }
+
+    @Test
+    public void sendsNotificationForRootLoginWithSanitizedValues() {
+        HttpServletRequest req = request("203.0.113.7", null, "host.example.com", "mysite");
+        listener.onEvent(rootEvent(req));
+
+        ArgumentCaptor<String> sender = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> recipient = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> subject = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        verify(mailService).sendMessage(sender.capture(), recipient.capture(), any(), any(),
+                subject.capture(), any(), body.capture());
+
+        assertThat(sender.getValue()).isEqualTo("noreply@example.com");
+        assertThat(recipient.getValue()).isEqualTo("security@example.com");
+        assertThat(subject.getValue()).isEqualTo("[host.example.com - mysite] root login");
+        assertThat(body.getValue()).contains("203.0.113.7");
+    }
+
+    @Test
+    public void doesNotSendForNonRootUser() {
+        BaseLoginEvent event = mock(BaseLoginEvent.class);
+        JahiaUser user = mock(JahiaUser.class);
+        when(user.isRoot()).thenReturn(false);
+        when(event.getJahiaUser()).thenReturn(user);
+
+        listener.onEvent(event);
+
+        verify(mailService, never()).sendMessage(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void doesNotSendWhenMailServiceDisabled() {
+        when(mailService.isEnabled()).thenReturn(false);
+
+        listener.onEvent(rootEvent(request(null, "10.0.0.1", "h", "s")));
+
+        verify(mailService, never()).sendMessage(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void stripsCrlfHeaderInjectionFromServerName() {
+        HttpServletRequest req = request("10.0.0.1", null,
+                "host\r\nBcc: attacker@evil.com", "mysite");
+        listener.onEvent(rootEvent(req));
+
+        // The header-injection vector is the CR/LF that would start a new header line; it must be
+        // stripped. Residual plain text on the same line is harmless (still inside the subject).
+        String subject = sentSubject();
+        assertThat(subject).doesNotContain("\r").doesNotContain("\n");
+    }
+
+    @Test
+    public void stripsCrlfHeaderInjectionFromSiteParameter() {
+        HttpServletRequest req = request("10.0.0.1", null, "host",
+                "site\r\nCc: attacker@evil.com");
+        listener.onEvent(rootEvent(req));
+
+        String subject = sentSubject();
+        assertThat(subject).doesNotContain("\r").doesNotContain("\n");
+    }
+
+    @Test
+    public void stripsCrlfFromConfiguredRecipientAndSender() {
+        when(config.getRecipient()).thenReturn("ok@example.com\r\nBcc: evil@evil.com");
+        when(config.getSender()).thenReturn("from@example.com\nX-Injected: 1");
+        HttpServletRequest req = request("10.0.0.1", null, "host", "site");
+        listener.onEvent(rootEvent(req));
+
+        ArgumentCaptor<String> sender = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> recipient = ArgumentCaptor.forClass(String.class);
+        verify(mailService).sendMessage(sender.capture(), recipient.capture(), any(), any(),
+                any(), any(), any());
+
+        assertThat(recipient.getValue()).doesNotContain("\r").doesNotContain("\n");
+        assertThat(sender.getValue()).doesNotContain("\r").doesNotContain("\n");
+    }
+
+    @Test
+    public void keepsFirstEntryOfXForwardedForChain() {
+        HttpServletRequest req = request("198.51.100.9, 10.0.0.1, 10.0.0.2", null, "host", "site");
+        listener.onEvent(rootEvent(req));
+
+        ArgumentCaptor<String> body = ArgumentCaptor.forClass(String.class);
+        verify(mailService).sendMessage(any(), any(), any(), any(), any(), any(), body.capture());
+        assertThat(body.getValue()).contains("198.51.100.9").doesNotContain("10.0.0.2");
+    }
+
+    @Test
+    public void doesNotThrowWhenSendMessageFails() {
+        doThrow(new RuntimeException("SMTP down")).when(mailService)
+                .sendMessage(any(), any(), any(), any(), any(), any(), any());
+        HttpServletRequest req = request("10.0.0.1", null, "host", "site");
+
+        // Must not propagate: a notification failure cannot break the login flow.
+        listener.onEvent(rootEvent(req));
+
+        verify(mailService).sendMessage(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void doesNotThrowWhenJahiaUserIsNull() {
+        BaseLoginEvent event = mock(BaseLoginEvent.class);
+        when(event.getJahiaUser()).thenReturn(null);
+
+        listener.onEvent(event);
+
+        verify(mailService, never()).sendMessage(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void doesNotThrowWhenRequestIsNull() {
+        BaseLoginEvent event = rootEvent(null);
+
+        listener.onEvent(event);
+
+        // No request -> empty host/ip, but recipient default present, so mail still sent without throwing.
+        verify(mailService).sendMessage(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void skipsSendWhenNoRecipientAvailable() {
+        when(mailService.defaultRecipient()).thenReturn(null);
+        when(config.getRecipient()).thenReturn(null);
+        HttpServletRequest req = request("10.0.0.1", null, "host", "site");
+
+        listener.onEvent(rootEvent(req));
+
+        verify(mailService, never()).sendMessage(any(), any(), any(), any(), any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Summary

Behavior-preserving hardening of `RootLoginListener` (the listener that emails on root login). The subject/body host/IP/site values were already sanitized; this PR closes the remaining gaps.

### Changes

- **S1 — Error handling (no swallow, login not broken):** the notification logic was previously unguarded — an SMTP failure or any NPE would propagate into the login event flow. Now wrapped in try/catch with an SLF4J logger: failures are logged, never propagated.
- **S2 — Null safety:** guard `getJahiaUser()`, `getAuthValveContext()`, `getRequest()` (null for programmatic logins) and null `mailService`/`config`.
- **S3 — Recipient/sender CRLF sanitization (defense-in-depth):** the GraphQL mutation validates email format, but the OSGi `.cfg` file can set recipient/sender directly, bypassing it. `sanitizeAddress` strips CR/LF + any non-address chars before `sendMessage`.
- **S4 — Subject header CRLF sanitization:** the subject *template* itself is user-controlled (config), so the fully-assembled subject is sanitized for CR/LF.
- **S5 — Recipient skip:** if no recipient is configured and no MailService default exists, log a warning and skip instead of sending to an empty address.
- **R1 — Cleanup:** `resolveRemoteAddress`/`resolveSite` helpers; magic numbers (0x20/0x7F, default site) -> named constants.
- **R2/R3 — Tests:** added JUnit4 test deps (the jahia-modules parent pins the surefire-junit4 provider) and `RootLoginListenerTest` (11 tests).

Frontend MF config (`richtext-ckeditor5`) untouched.

## Test plan

- `mvn clean install` -> BUILD SUCCESS, **Tests run: 11, Failures: 0, Errors: 0** (confirmed N>0, tests truly execute under surefire).
- Coverage: root login send path, non-root skip, mail-disabled skip, CRLF stripping (server/site/recipient/sender), x-forwarded-for chain handling, send-failure does not throw, null user/request safety, no-recipient skip.