### PR TITLE
feat: add rootLoginNotificationAdmin permission for fine-grained RBAC

### DIFF
--- a/src/javascript/RootLoginNotification/register.jsx
+++ b/src/javascript/RootLoginNotification/register.jsx
@@ -6,7 +6,7 @@ export default () => {
     console.debug('%c root-login-notification: activation in progress', 'color: #006633');
     registry.add('adminRoute', 'rootLoginNotification', {
         targets: ['administration-server-configuration:20'],
-        requiredPermission: 'admin',
+        requiredPermission: 'rootLoginNotificationAdmin',
         label: 'root-login-notification:label.menu_entry',
         isSelectable: true,
         render: () => React.createElement(RootLoginNotificationAdmin)

--- a/src/main/import/permissions.xml
+++ b/src/main/import/permissions.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns:jcr="http://www.jcp.org/jcr/1.0">
+    <admin jcr:primaryType="jnt:permission">
+        <rootLoginNotificationAdmin jcr:primaryType="jnt:permission"/>
+    </admin>
+</permissions>

--- a/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
@@ -34,7 +34,7 @@ public class RootLoginNotificationMutationExtension {
     @GraphQLField
     @GraphQLName("rootLoginNotificationSaveSettings")
     @GraphQLDescription("Saves the root login notification mail settings")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("rootLoginNotificationAdmin")
     public static Boolean saveSettings(
             @GraphQLName("recipient") @GraphQLDescription("Custom recipient email (optional, leave empty to use MailService default)") String recipient,
             @GraphQLName("sender") @GraphQLDescription("Custom sender email (optional, leave empty to use MailService default)") String sender,

--- a/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationQueryExtension.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationQueryExtension.java
@@ -20,7 +20,7 @@ public class RootLoginNotificationQueryExtension {
     @GraphQLField
     @GraphQLName("rootLoginNotificationSettings")
     @GraphQLDescription("Returns the current root login notification mail settings")
-    @GraphQLRequiresPermission("admin")
+    @GraphQLRequiresPermission("rootLoginNotificationAdmin")
     public static GqlSettings settings() {
         final RootLoginNotificationConfig config = BundleUtils.getOsgiService(RootLoginNotificationConfig.class, null);
         if (config == null) {


### PR DESCRIPTION
## Summary

- Adds `src/main/import/permissions.xml` defining `rootLoginNotificationAdmin` as a child of the built-in `admin` JCR permission, so full admins keep access via inheritance.
- Replaces `@GraphQLRequiresPermission("admin")` with `@GraphQLRequiresPermission("rootLoginNotificationAdmin")` in both GraphQL extension classes (`RootLoginNotificationQueryExtension` and `RootLoginNotificationMutationExtension`).
- No changes to Java logic, tests, or `pom.xml`.

## Test plan

- [ ] `mvn clean install` passes (verified locally — build output confirms `import.zip` packaged).
- [ ] Deploy module to a Jahia instance and verify the `rootLoginNotificationAdmin` permission appears under `admin` in the JCR permissions tree (`/permissions/admin/rootLoginNotificationAdmin`).
- [ ] Confirm a user with only `rootLoginNotificationAdmin` can call both GraphQL operations (`rootLoginNotificationSettings` query, `rootLoginNotificationSaveSettings` mutation).
- [ ] Confirm a full `admin` user still has access (JCR privilege inheritance).
- [ ] Confirm a user without the permission receives a 403 / permission-denied error on both operations.
- [ ] Existing Cypress e2e suite passes against a Jahia instance with the module deployed (root login email flow unaffected).