### PR TITLE
test: fine-grained permission regression tests + assignable admin role

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.jahia.community</groupId>
     <artifactId>root-login-notification</artifactId>
     <name>root login notification</name>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>2.0.4-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>Jahia module that sends an email notification when the root user logs in.</description>
 

--- a/src/main/import/roles.xml
+++ b/src/main/import/roles.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roles jcr:primaryType="jnt:roles"
+       xmlns:jcr="http://www.jcp.org/jcr/1.0"
+       xmlns:j="http://www.jahia.org/jahia/1.0"
+       xmlns:jnt="http://www.jahia.org/jahia/nt/1.0">
+
+    <root-login-notification-administrator jcr:primaryType="jnt:role"
+                                           j:nodeTypes="rep:root"
+                                           j:roleGroup="server-role"
+                                           j:permissionNames="administrationAccess rootLoginNotificationAdmin"
+                                           j:privilegedAccess="true">
+        <j:translation_en jcr:primaryType="jnt:translation"
+                          jcr:language="en"
+                          jcr:title="Root Login Notification administrator"
+                          jcr:description="Grants access to the Root Login Notification administration without requiring full server administrator rights"/>
+    </root-login-notification-administrator>
+</roles>

--- a/tests/cypress/e2e/02-rootLoginNotification-Permissions.cy.ts
+++ b/tests/cypress/e2e/02-rootLoginNotification-Permissions.cy.ts
@@ -1,0 +1,86 @@
+import {DocumentNode} from 'graphql';
+import {createUser, deleteUser, grantRoles} from '@jahia/cypress';
+
+/**
+ * Regression tests for the fine-grained `rootLoginNotificationAdmin` permission.
+ *
+ * These guard against the gate being silently removed or mismatched across the stack:
+ *  - Backend: `@GraphQLRequiresPermission("rootLoginNotificationAdmin")` is enforced as
+ *    `session.getNode("/").hasPermission("rootLoginNotificationAdmin")` (root-node ACL check).
+ *  - Frontend: `requiredPermission: 'rootLoginNotificationAdmin'` in register.jsx gates the admin route.
+ *  - RBAC content: the module ships the assignable `root-login-notification-administrator` role
+ *    (src/main/import/roles.xml) granting `administrationAccess` + that permission only.
+ *
+ * The "allowed" user is granted that role and nothing else — never `admin` — so the tests prove
+ * fine-grained granularity, not merely that a full administrator can pass.
+ */
+describe('Root Login Notification — permission enforcement', () => {
+    const ROLE_NAME = 'root-login-notification-administrator';
+    const DENIED_USER = 'rlnDeniedUser';
+    const ALLOWED_USER = 'rlnAllowedUser';
+    const PASSWORD = 'RlnPerm9PwdTest';
+    const ADMIN_PATH = '/jahia/administration/rootLoginNotification';
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const getSettings: DocumentNode = require('graphql-tag/loader!../fixtures/graphql/query/getSettings.graphql');
+
+    const errorsOf = (result: {graphQLErrors?: Array<{message: string}>; errors?: Array<{message: string}>}) =>
+        result.graphQLErrors ?? result.errors ?? [];
+
+    const querySettingsAs = (username: string) => {
+        cy.apolloClient({username, password: PASSWORD});
+        return cy.apollo({query: getSettings});
+    };
+
+    before(() => {
+        cy.login();
+        createUser(DENIED_USER, PASSWORD);
+        createUser(ALLOWED_USER, PASSWORD);
+        // The annotation resolves the permission on the JCR root node, so grant the
+        // module-shipped role on `/`.
+        grantRoles('/', [ROLE_NAME], ALLOWED_USER, 'USER');
+    });
+
+    after(() => {
+        cy.apolloClient(); // reset the current Apollo client back to root
+        cy.login();
+        deleteUser(DENIED_USER);
+        deleteUser(ALLOWED_USER);
+    });
+
+    describe('GraphQL API authorization', () => {
+        it('denies the gated query for a user without the permission', () => {
+            querySettingsAs(DENIED_USER).then((result: never) => {
+                const errs = errorsOf(result);
+                expect(errs, 'denial errors').to.have.length.greaterThan(0);
+                expect(errs.map((e: {message: string}) => e.message).join(' ')).to.contain('Permission denied');
+            });
+        });
+
+        it('allows the gated query for a user granted only the module permission', () => {
+            querySettingsAs(ALLOWED_USER).then((result: never) => {
+                expect(errorsOf(result), 'should have no errors').to.have.length(0);
+                const settings = (result as {data: {rootLoginNotificationSettings: Record<string, unknown>}})
+                    .data.rootLoginNotificationSettings;
+                expect(settings).to.have.property('recipient');
+                expect(settings).to.have.property('sender');
+                expect(settings).to.have.property('subject');
+                expect(settings).to.have.property('body');
+            });
+        });
+    });
+
+    describe('Admin UI authorization', () => {
+        it('hides the admin panel from a user without the permission', () => {
+            cy.login(DENIED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH, {failOnStatusCode: false});
+            cy.contains('Root Login Notification Settings').should('not.exist');
+        });
+
+        it('shows the admin panel to a user granted only the module permission', () => {
+            cy.login(ALLOWED_USER, PASSWORD);
+            cy.visit(ADMIN_PATH);
+            cy.contains('Root Login Notification Settings').should('be.visible');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds regression coverage for the fine-grained `rootLoginNotificationAdmin` permission and ships an assignable server role so the Root Login Notification admin UI / GraphQL API can be delegated without granting full server-administrator rights.

- **New role** `root-login-notification-administrator` (`src/main/import/roles.xml`), `j:permissionNames="administrationAccess rootLoginNotificationAdmin"` — no `admin`. `administrationAccess` is required so the admin-UI entry renders for the grantee.
- **New Cypress spec** `tests/cypress/e2e/02-rootLoginNotification-Permissions.cy.ts` (4 tests). The "allowed" user is granted only the module role (never `admin`), proving fine-grained granularity:
  - GraphQL deny: gated `rootLoginNotificationSettings` query returns `Permission denied` for a user without the permission.
  - GraphQL allow: same read-only query succeeds (full settings payload, no errors) for a user with only the module role.
  - Admin UI hidden: panel does not render for the denied user.
  - Admin UI shown: panel renders for the allowed user (reuses the existing `Root Login Notification Settings` assertion from spec 01).
- **Version bump** `2.0.3-SNAPSHOT` → `2.0.4-SNAPSHOT` so the new `roles.xml` import content re-imports on deploy.

### No backend relaxation required
The resolvers gate solely via `@GraphQLRequiresPermission("rootLoginNotificationAdmin")` (resolved as a root-node ACL check). There is **no** inner hardcoded `admin` / `hasPermission("admin")` check, so the fine-grained role already works end-to-end — no `.java` changes needed.

## Test plan
- `cd tests && ./ci.build.sh && ./ci.startup.sh` → **2/2 specs pass, 20/20 tests** (16 existing + 4 new).
- License health check (`Premature end of file` / `getJahiaLicensePackage ... null`): 0 occurrences.