### PR TITLE
Reduce saveSettings cognitive complexity (S3776) + lint cleanup

### DIFF
--- a/src/javascript/RootLoginNotification/RootLoginNotification.jsx
+++ b/src/javascript/RootLoginNotification/RootLoginNotification.jsx
@@ -224,13 +224,13 @@ export const RootLoginNotificationAdmin = () => {
                     </span>
                     <input
                         ref={recipientInputRef}
+                        required
                         type="email"
                         id="rln-recipient"
                         className={`${styles.rln_input}${errors.recipient ? ` ${styles['rln_input--error']}` : ''}`}
                         value={formState.recipient}
                         placeholder={t('label.recipientPlaceholder')}
                         autoComplete="email"
-                        required
                         aria-invalid={Boolean(errors.recipient)}
                         aria-describedby={['rln-recipient-hint', errors.recipient ? 'rln-recipient-error' : ''].filter(Boolean).join(' ')}
                         onChange={handleChange('recipient')}
@@ -252,13 +252,13 @@ export const RootLoginNotificationAdmin = () => {
                     </span>
                     <input
                         ref={senderInputRef}
+                        required
                         type="email"
                         id="rln-sender"
                         className={`${styles.rln_input}${errors.sender ? ` ${styles['rln_input--error']}` : ''}`}
                         value={formState.sender}
                         placeholder={t('label.senderPlaceholder')}
                         autoComplete="email"
-                        required
                         aria-invalid={Boolean(errors.sender)}
                         aria-describedby={['rln-sender-hint', errors.sender ? 'rln-sender-error' : ''].filter(Boolean).join(' ')}
                         onChange={handleChange('sender')}

--- a/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
@@ -31,6 +31,18 @@ public class RootLoginNotificationMutationExtension {
         return email == null || email.isEmpty() || EMAIL_PATTERN.matcher(email).matches();
     }
 
+    /**
+     * Sets {@code key} to {@code value} when non-empty, otherwise removes it so the
+     * module falls back to its default for that setting.
+     */
+    private static void putOrRemove(Dictionary<String, Object> props, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            props.put(key, value);
+        } else {
+            props.remove(key);
+        }
+    }
+
     @GraphQLField
     @GraphQLName("rootLoginNotificationSaveSettings")
     @GraphQLDescription("Saves the root login notification mail settings")
@@ -56,28 +68,10 @@ public class RootLoginNotificationMutationExtension {
             if (props == null) {
                 props = new Hashtable<>();
             }
-            if (recipient != null && !recipient.isEmpty()) {
-                props.put("recipient", recipient);
-            } else {
-                props.remove("recipient");
-            }
-            if (sender != null && !sender.isEmpty()) {
-                props.put("sender", sender);
-            } else {
-                props.remove("sender");
-            }
-            if (subject != null && !subject.isEmpty()) {
-                props.put("subject", subject);
-            } else {
-                props.remove("subject");
-                LOGGER.debug("subject not provided or empty — removed from config (default will be used)");
-            }
-            if (body != null && !body.isEmpty()) {
-                props.put("body", body);
-            } else {
-                props.remove("body");
-                LOGGER.debug("body not provided or empty — removed from config (default will be used)");
-            }
+            putOrRemove(props, "recipient", recipient);
+            putOrRemove(props, "sender", sender);
+            putOrRemove(props, "subject", subject);
+            putOrRemove(props, "body", body);
             config.update(props);
             return Boolean.TRUE;
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

Blind review of `root-login-notification`. The module is otherwise well-hardened (input sanitization for SMTP-header/XSS, permission-gated GraphQL, mailpit-backed Cypress), but SonarQube flagged one outstanding **CRITICAL** issue and the admin panel had two lint errors.

- **Sonar S3776 (CRITICAL):** `RootLoginNotificationMutationExtension.saveSettings` had cognitive complexity 17 (> 15). The four `set-when-non-empty / remove-when-empty` config blocks are extracted into a single `putOrRemove(props, key, value)` helper, dropping complexity below the threshold and removing duplication. **Behavior is unchanged** — sending an empty value still removes the override so the module falls back to its default.
- **Lint:** auto-fixed two `react/jsx-sort-props` errors in `RootLoginNotification.jsx`.

## Test plan
- [x] `mvn clean install sonar:sonar` — BUILD SUCCESS, 11 Java tests pass, Sonar gate OK, **0 open issues** (S3776 resolved)
- [x] `eslint src/javascript` — 0 errors / 0 warnings
- [x] Cypress Docker (jahia + mailpit + cypress) — **20/20** pass (16 functional + 4 permission), incl. email-delivery via mailpit