### PR TITLE
refactor: nest GraphQL operations under a rootLoginNotification namespace container

### DIFF
--- a/src/javascript/RootLoginNotification/RootLoginNotification.gql.js
+++ b/src/javascript/RootLoginNotification/RootLoginNotification.gql.js
@@ -2,17 +2,21 @@ import {gql} from '@apollo/client';
 
 export const GET_SETTINGS = gql`
     query {
-        rootLoginNotificationSettings {
-            recipient
-            sender
-            subject
-            body
+        rootLoginNotification {
+            settings {
+                recipient
+                sender
+                subject
+                body
+            }
         }
     }
 `;
 
 export const SAVE_SETTINGS = gql`
     mutation RootLoginNotificationSaveSettings($recipient: String, $sender: String, $subject: String, $body: String) {
-        rootLoginNotificationSaveSettings(recipient: $recipient, sender: $sender, subject: $subject, body: $body)
+        rootLoginNotification {
+            saveSettings(recipient: $recipient, sender: $sender, subject: $subject, body: $body)
+        }
     }
 `;

--- a/src/javascript/RootLoginNotification/RootLoginNotification.jsx
+++ b/src/javascript/RootLoginNotification/RootLoginNotification.jsx
@@ -99,7 +99,7 @@ export const RootLoginNotificationAdmin = () => {
     const {loading} = useQuery(GET_SETTINGS, {
         fetchPolicy: 'network-only',
         onCompleted: data => {
-            const s = data?.rootLoginNotificationSettings;
+            const s = data?.rootLoginNotification?.settings;
             if (s) {
                 setFormState({
                     recipient: s.recipient ?? '',
@@ -166,7 +166,7 @@ export const RootLoginNotificationAdmin = () => {
                     body: formState.body
                 }
             });
-            setSaveStatus(result.data?.rootLoginNotificationSaveSettings ? 'success' : 'error');
+            setSaveStatus(result.data?.rootLoginNotification?.saveSettings ? 'success' : 'error');
         } catch (err) {
             console.error('Failed to save settings:', err);
             setSaveStatus('error');

--- a/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutation.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutation.java
@@ -1,0 +1,76 @@
+package org.jahia.modules.rootloginnotification.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.osgi.BundleUtils;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.regex.Pattern;
+
+@GraphQLName("RootLoginNotificationMutation")
+@GraphQLDescription("Root login notification mutations")
+public class RootLoginNotificationMutation {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RootLoginNotificationMutation.class);
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
+
+    private static boolean isValidEmail(String email) {
+        return email == null || email.isEmpty() || EMAIL_PATTERN.matcher(email).matches();
+    }
+
+    /**
+     * Sets {@code key} to {@code value} when non-empty, otherwise removes it so the
+     * module falls back to its default for that setting.
+     */
+    private static void putOrRemove(Dictionary<String, Object> props, String key, String value) {
+        if (value != null && !value.isEmpty()) {
+            props.put(key, value);
+        } else {
+            props.remove(key);
+        }
+    }
+
+    @GraphQLField
+    @GraphQLName("saveSettings")
+    @GraphQLDescription("Saves the root login notification mail settings")
+    @GraphQLRequiresPermission("rootLoginNotificationAdmin")
+    public Boolean saveSettings(
+            @GraphQLName("recipient") @GraphQLDescription("Custom recipient email (optional, leave empty to use MailService default)") String recipient,
+            @GraphQLName("sender") @GraphQLDescription("Custom sender email (optional, leave empty to use MailService default)") String sender,
+            @GraphQLName("subject") @GraphQLDescription("Subject template — tokens: {server}, {site}") String subject,
+            @GraphQLName("body") @GraphQLDescription("Body template — tokens: {ip}, {time}") String body) {
+        if (!isValidEmail(recipient)) {
+            throw new IllegalArgumentException("Invalid recipient email address");
+        }
+        if (!isValidEmail(sender)) {
+            throw new IllegalArgumentException("Invalid sender email address");
+        }
+        try {
+            final ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
+            if (configAdmin == null) {
+                return Boolean.FALSE;
+            }
+            final Configuration config = configAdmin.getConfiguration("org.jahia.modules.rootloginnotification", null);
+            Dictionary<String, Object> props = config.getProperties();
+            if (props == null) {
+                props = new Hashtable<>();
+            }
+            putOrRemove(props, "recipient", recipient);
+            putOrRemove(props, "sender", sender);
+            putOrRemove(props, "subject", subject);
+            putOrRemove(props, "body", body);
+            config.update(props);
+            return Boolean.TRUE;
+        } catch (Exception e) {
+            LOGGER.error("Failed to save root login notification settings", e);
+            return Boolean.FALSE;
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
@@ -5,78 +5,18 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.osgi.BundleUtils;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.regex.Pattern;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Mutation.class)
-@GraphQLName("RootLoginNotificationMutations")
-@GraphQLDescription("Root Login Notification mutations")
+@GraphQLDescription("Root login notification mutations")
 public class RootLoginNotificationMutationExtension {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(RootLoginNotificationMutationExtension.class);
-    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$");
 
     private RootLoginNotificationMutationExtension() {
     }
 
-    private static boolean isValidEmail(String email) {
-        return email == null || email.isEmpty() || EMAIL_PATTERN.matcher(email).matches();
-    }
-
-    /**
-     * Sets {@code key} to {@code value} when non-empty, otherwise removes it so the
-     * module falls back to its default for that setting.
-     */
-    private static void putOrRemove(Dictionary<String, Object> props, String key, String value) {
-        if (value != null && !value.isEmpty()) {
-            props.put(key, value);
-        } else {
-            props.remove(key);
-        }
-    }
-
     @GraphQLField
-    @GraphQLName("rootLoginNotificationSaveSettings")
-    @GraphQLDescription("Saves the root login notification mail settings")
-    @GraphQLRequiresPermission("rootLoginNotificationAdmin")
-    public static Boolean saveSettings(
-            @GraphQLName("recipient") @GraphQLDescription("Custom recipient email (optional, leave empty to use MailService default)") String recipient,
-            @GraphQLName("sender") @GraphQLDescription("Custom sender email (optional, leave empty to use MailService default)") String sender,
-            @GraphQLName("subject") @GraphQLDescription("Subject template — tokens: {server}, {site}") String subject,
-            @GraphQLName("body") @GraphQLDescription("Body template — tokens: {ip}, {time}") String body) {
-        if (!isValidEmail(recipient)) {
-            throw new IllegalArgumentException("Invalid recipient email address");
-        }
-        if (!isValidEmail(sender)) {
-            throw new IllegalArgumentException("Invalid sender email address");
-        }
-        try {
-            final ConfigurationAdmin configAdmin = BundleUtils.getOsgiService(ConfigurationAdmin.class, null);
-            if (configAdmin == null) {
-                return Boolean.FALSE;
-            }
-            final Configuration config = configAdmin.getConfiguration("org.jahia.modules.rootloginnotification", null);
-            Dictionary<String, Object> props = config.getProperties();
-            if (props == null) {
-                props = new Hashtable<>();
-            }
-            putOrRemove(props, "recipient", recipient);
-            putOrRemove(props, "sender", sender);
-            putOrRemove(props, "subject", subject);
-            putOrRemove(props, "body", body);
-            config.update(props);
-            return Boolean.TRUE;
-        } catch (Exception e) {
-            LOGGER.error("Failed to save root login notification settings", e);
-            return Boolean.FALSE;
-        }
+    @GraphQLName("rootLoginNotification")
+    @GraphQLDescription("Root login notification mutation namespace")
+    public static RootLoginNotificationMutation rootLoginNotification() {
+        return new RootLoginNotificationMutation();
     }
 }

--- a/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationQuery.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationQuery.java
@@ -1,0 +1,76 @@
+package org.jahia.modules.rootloginnotification.graphql;
+
+import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLName;
+import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
+import org.jahia.modules.rootloginnotification.RootLoginNotificationConfig;
+import org.jahia.osgi.BundleUtils;
+
+@GraphQLName("RootLoginNotificationQuery")
+@GraphQLDescription("Root login notification queries")
+public class RootLoginNotificationQuery {
+
+    @GraphQLField
+    @GraphQLName("settings")
+    @GraphQLDescription("Returns the current root login notification mail settings")
+    @GraphQLRequiresPermission("rootLoginNotificationAdmin")
+    public GqlSettings settings() {
+        final RootLoginNotificationConfig config = BundleUtils.getOsgiService(RootLoginNotificationConfig.class, null);
+        if (config == null) {
+            return GqlSettings.defaults();
+        }
+        return new GqlSettings(config.getRecipient(), config.getSender(), config.getSubject(), config.getBody());
+    }
+
+    @GraphQLName("RootLoginNotificationSettings")
+    @GraphQLDescription("Root login notification mail settings")
+    public static class GqlSettings {
+
+        private final String recipient;
+        private final String sender;
+        private final String subject;
+        private final String body;
+
+        public GqlSettings(String recipient, String sender, String subject, String body) {
+            this.recipient = recipient;
+            this.sender = sender;
+            this.subject = subject;
+            this.body = body;
+        }
+
+        public static GqlSettings defaults() {
+            return new GqlSettings(null, null,
+                    RootLoginNotificationConfig.DEFAULT_SUBJECT,
+                    RootLoginNotificationConfig.DEFAULT_BODY);
+        }
+
+        @GraphQLField
+        @GraphQLName("recipient")
+        @GraphQLDescription("Custom recipient email, null if using the MailService default")
+        public String getRecipient() {
+            return recipient;
+        }
+
+        @GraphQLField
+        @GraphQLName("sender")
+        @GraphQLDescription("Custom sender email, null if using the MailService default")
+        public String getSender() {
+            return sender;
+        }
+
+        @GraphQLField
+        @GraphQLName("subject")
+        @GraphQLDescription("Subject template. Tokens: {server}, {site}")
+        public String getSubject() {
+            return subject;
+        }
+
+        @GraphQLField
+        @GraphQLName("body")
+        @GraphQLDescription("Body template. Tokens: {ip}, {time}")
+        public String getBody() {
+            return body;
+        }
+    }
+}

--- a/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationQueryExtension.java
+++ b/src/main/java/org/jahia/modules/rootloginnotification/graphql/RootLoginNotificationQueryExtension.java
@@ -5,78 +5,18 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeExtension;
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLProvider;
-import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.modules.rootloginnotification.RootLoginNotificationConfig;
-import org.jahia.osgi.BundleUtils;
 
 @GraphQLTypeExtension(DXGraphQLProvider.Query.class)
-@GraphQLName("RootLoginNotificationQueries")
-@GraphQLDescription("Root Login Notification queries")
+@GraphQLDescription("Root login notification queries")
 public class RootLoginNotificationQueryExtension {
 
     private RootLoginNotificationQueryExtension() {
     }
 
     @GraphQLField
-    @GraphQLName("rootLoginNotificationSettings")
-    @GraphQLDescription("Returns the current root login notification mail settings")
-    @GraphQLRequiresPermission("rootLoginNotificationAdmin")
-    public static GqlSettings settings() {
-        final RootLoginNotificationConfig config = BundleUtils.getOsgiService(RootLoginNotificationConfig.class, null);
-        if (config == null) {
-            return GqlSettings.defaults();
-        }
-        return new GqlSettings(config.getRecipient(), config.getSender(), config.getSubject(), config.getBody());
-    }
-
-    @GraphQLName("RootLoginNotificationSettings")
-    @GraphQLDescription("Root login notification mail settings")
-    public static class GqlSettings {
-
-        private final String recipient;
-        private final String sender;
-        private final String subject;
-        private final String body;
-
-        public GqlSettings(String recipient, String sender, String subject, String body) {
-            this.recipient = recipient;
-            this.sender = sender;
-            this.subject = subject;
-            this.body = body;
-        }
-
-        public static GqlSettings defaults() {
-            return new GqlSettings(null, null,
-                    RootLoginNotificationConfig.DEFAULT_SUBJECT,
-                    RootLoginNotificationConfig.DEFAULT_BODY);
-        }
-
-        @GraphQLField
-        @GraphQLName("recipient")
-        @GraphQLDescription("Custom recipient email, null if using the MailService default")
-        public String getRecipient() {
-            return recipient;
-        }
-
-        @GraphQLField
-        @GraphQLName("sender")
-        @GraphQLDescription("Custom sender email, null if using the MailService default")
-        public String getSender() {
-            return sender;
-        }
-
-        @GraphQLField
-        @GraphQLName("subject")
-        @GraphQLDescription("Subject template. Tokens: {server}, {site}")
-        public String getSubject() {
-            return subject;
-        }
-
-        @GraphQLField
-        @GraphQLName("body")
-        @GraphQLDescription("Body template. Tokens: {ip}, {time}")
-        public String getBody() {
-            return body;
-        }
+    @GraphQLName("rootLoginNotification")
+    @GraphQLDescription("Root login notification query namespace")
+    public static RootLoginNotificationQuery rootLoginNotification() {
+        return new RootLoginNotificationQuery();
     }
 }

--- a/tests/cypress/e2e/01-rootLoginNotification.cy.ts
+++ b/tests/cypress/e2e/01-rootLoginNotification.cy.ts
@@ -30,7 +30,7 @@ describe('Root Login Notification', () => {
     describe('Settings API', () => {
         it('returns all settings fields via GraphQL', () => {
             cy.apollo({query: getSettings})
-                .its('data.rootLoginNotificationSettings')
+                .its('data.rootLoginNotification.settings')
                 .should(s => {
                     expect(s).to.have.property('recipient');
                     expect(s).to.have.property('sender');
@@ -47,7 +47,7 @@ describe('Root Login Notification', () => {
                     body: '<p>Test body {ip} {time}</p>'
                 }
             })
-                .its('data.rootLoginNotificationSaveSettings')
+                .its('data.rootLoginNotification.saveSettings')
                 .should('eq', true);
         });
 
@@ -62,7 +62,7 @@ describe('Root Login Notification', () => {
                 }
             });
             cy.apollo({query: getSettings})
-                .its('data.rootLoginNotificationSettings')
+                .its('data.rootLoginNotification.settings')
                 .should(s => {
                     expect(s.recipient).to.eq('roundtrip@jahia.test');
                     expect(s.subject).to.eq(testSubject);
@@ -80,7 +80,7 @@ describe('Root Login Notification', () => {
                 }
             });
             cy.apollo({query: getSettings})
-                .its('data.rootLoginNotificationSettings')
+                .its('data.rootLoginNotification.settings')
                 .should(s => {
                     expect(s.recipient).to.be.null;
                     expect(s.sender).to.be.null;
@@ -98,7 +98,7 @@ describe('Root Login Notification', () => {
                 errorPolicy: 'all'
             }).should(result => {
                 // The mutation should either return false or throw a GraphQL error
-                const saved = result.data?.rootLoginNotificationSaveSettings;
+                const saved = result.data?.rootLoginNotification?.saveSettings;
                 const hasErrors = result.errors && result.errors.length > 0;
                 expect(saved === false || hasErrors).to.be.true;
             });

--- a/tests/cypress/e2e/02-rootLoginNotification-Permissions.cy.ts
+++ b/tests/cypress/e2e/02-rootLoginNotification-Permissions.cy.ts
@@ -60,8 +60,8 @@ describe('Root Login Notification — permission enforcement', () => {
         it('allows the gated query for a user granted only the module permission', () => {
             querySettingsAs(ALLOWED_USER).then((result: never) => {
                 expect(errorsOf(result), 'should have no errors').to.have.length(0);
-                const settings = (result as {data: {rootLoginNotificationSettings: Record<string, unknown>}})
-                    .data.rootLoginNotificationSettings;
+                const settings = (result as {data: {rootLoginNotification: {settings: Record<string, unknown>}}})
+                    .data.rootLoginNotification.settings;
                 expect(settings).to.have.property('recipient');
                 expect(settings).to.have.property('sender');
                 expect(settings).to.have.property('subject');

--- a/tests/cypress/fixtures/graphql/mutation/saveSettings.graphql
+++ b/tests/cypress/fixtures/graphql/mutation/saveSettings.graphql
@@ -1,8 +1,10 @@
 mutation saveSettings($recipient: String, $sender: String, $subject: String, $body: String) {
-    rootLoginNotificationSaveSettings(
-        recipient: $recipient
-        sender: $sender
-        subject: $subject
-        body: $body
-    )
+    rootLoginNotification {
+        saveSettings(
+            recipient: $recipient
+            sender: $sender
+            subject: $subject
+            body: $body
+        )
+    }
 }

--- a/tests/cypress/fixtures/graphql/query/getSettings.graphql
+++ b/tests/cypress/fixtures/graphql/query/getSettings.graphql
@@ -1,8 +1,10 @@
 query {
-    rootLoginNotificationSettings {
-        recipient
-        sender
-        subject
-        body
+    rootLoginNotification {
+        settings {
+            recipient
+            sender
+            subject
+            body
+        }
     }
 }


### PR DESCRIPTION
## What & why
Brings the module in line with the Jahia GraphQL convention: group operations under **one hierarchical namespace container** instead of flat, prefix-named root fields.

### Schema change (breaking)
```graphql
# before: query { rootLoginNotificationSettings { ... } }
# after:  query { rootLoginNotification { settings { ... } } }
```
Same for the mutation (`rootLoginNotification { saveSettings(...) }`).

### How
- New holder types `RootLoginNotificationQuery` / `RootLoginNotificationMutation` hold the operations as instance `@GraphQLField` methods (`settings`, `saveSettings`); the nested `GqlSettings` return type moved into the query holder.
- The `*Extension` classes keep a single `rootLoginNotification` accessor field.
- `@GraphQLRequiresPermission` stays on each leaf — authorization unchanged.
- Frontend (`*.gql.js`/`.jsx`) and Cypress fixtures/specs updated in lockstep.

## Verification
- `mvn clean install` (JDK17): **BUILD SUCCESS**, 11 JUnit tests pass, webpack OK
- Cypress E2E: **20/20 pass** (functional + permission — mailpit)
- SonarQube quality gate: **OK** (0 new issues, 0 duplication)