### PR TITLE
refactor: rename root package org.jahia.modules.* → org.jahia.community.*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ Jahia OSGi module that sends an email notification whenever the root account suc
 ## Key Facts
 
 - **artifactId**: `root-login-notification` | **version**: `2.0.2-SNAPSHOT`
-- **Java package**: `org.jahia.modules.rootloginnotification`
+- **Java package**: `org.jahia.community.rootloginnotification`
 - **jahia-depends**: `default,graphql-dxm-provider,richtext-ckeditor5`
-- **OSGi config PID**: `org.jahia.modules.rootloginnotification`
+- **OSGi config PID**: `org.jahia.community.rootloginnotification`
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Settings can also be managed via file or GraphQL — see the sections below.
 
 ### File-based configuration
 
-Create or edit `org.jahia.modules.rootloginnotification.cfg` in the Jahia configuration directory:
+Create or edit `org.jahia.community.rootloginnotification.cfg` in the Jahia configuration directory:
 
 ```properties
 # Optional — leave commented to use the Jahia mail service default

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <_dsannotations>org.jahia.modules.rootloginnotification.*</_dsannotations>
+                        <_dsannotations>org.jahia.community.rootloginnotification.*</_dsannotations>
                     </instructions>
                 </configuration>
             </plugin>

--- a/src/main/java/org/jahia/community/rootloginnotification/RootLoginListener.java
+++ b/src/main/java/org/jahia/community/rootloginnotification/RootLoginListener.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.rootloginnotification;
+package org.jahia.community.rootloginnotification;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;

--- a/src/main/java/org/jahia/community/rootloginnotification/RootLoginNotificationConfig.java
+++ b/src/main/java/org/jahia/community/rootloginnotification/RootLoginNotificationConfig.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.rootloginnotification;
+package org.jahia.community.rootloginnotification;
 
 import org.osgi.framework.Constants;
 import org.osgi.service.cm.ConfigurationException;
@@ -10,7 +10,7 @@ import java.util.Dictionary;
 @Component(
         immediate = true,
         service = {RootLoginNotificationConfig.class, ManagedService.class},
-        property = Constants.SERVICE_PID + "=org.jahia.modules.rootloginnotification"
+        property = Constants.SERVICE_PID + "=org.jahia.community.rootloginnotification"
 )
 public class RootLoginNotificationConfig implements ManagedService {
 

--- a/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationGraphQLExtensionsProvider.java
+++ b/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationGraphQLExtensionsProvider.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.rootloginnotification.graphql;
+package org.jahia.community.rootloginnotification.graphql;
 
 import org.jahia.modules.graphql.provider.dxm.DXGraphQLExtensionsProvider;
 import org.osgi.service.component.annotations.Component;

--- a/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationMutation.java
+++ b/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationMutation.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.rootloginnotification.graphql;
+package org.jahia.community.rootloginnotification.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
@@ -57,7 +57,7 @@ public class RootLoginNotificationMutation {
             if (configAdmin == null) {
                 return Boolean.FALSE;
             }
-            final Configuration config = configAdmin.getConfiguration("org.jahia.modules.rootloginnotification", null);
+            final Configuration config = configAdmin.getConfiguration("org.jahia.community.rootloginnotification", null);
             Dictionary<String, Object> props = config.getProperties();
             if (props == null) {
                 props = new Hashtable<>();

--- a/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
+++ b/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationMutationExtension.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.rootloginnotification.graphql;
+package org.jahia.community.rootloginnotification.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;

--- a/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationQuery.java
+++ b/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationQuery.java
@@ -1,10 +1,10 @@
-package org.jahia.modules.rootloginnotification.graphql;
+package org.jahia.community.rootloginnotification.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import org.jahia.modules.graphql.provider.dxm.security.GraphQLRequiresPermission;
-import org.jahia.modules.rootloginnotification.RootLoginNotificationConfig;
+import org.jahia.community.rootloginnotification.RootLoginNotificationConfig;
 import org.jahia.osgi.BundleUtils;
 
 @GraphQLName("RootLoginNotificationQuery")

--- a/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationQueryExtension.java
+++ b/src/main/java/org/jahia/community/rootloginnotification/graphql/RootLoginNotificationQueryExtension.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.rootloginnotification.graphql;
+package org.jahia.community.rootloginnotification.graphql;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;

--- a/src/test/java/org/jahia/community/rootloginnotification/RootLoginListenerTest.java
+++ b/src/test/java/org/jahia/community/rootloginnotification/RootLoginListenerTest.java
@@ -1,4 +1,4 @@
-package org.jahia.modules.rootloginnotification;
+package org.jahia.community.rootloginnotification;
 
 import org.jahia.params.valves.AuthValveContext;
 import org.jahia.params.valves.BaseLoginEvent;


### PR DESCRIPTION
## Summary
Renames the module's own base Java package from `org.jahia.modules.rootloginnotification` to `org.jahia.community.rootloginnotification`, aligning the namespace with the `org.jahia.community` Maven groupId this community module already uses.

## Changes
- `git mv` of package directories (main + test) — history preserved
- bnd `_dsannotations` scan repointed to the new package
- AGENTS.md / README references updated

## Deliberately unchanged
- Jahia GraphQL provider API imports (`org.jahia.modules.graphql.provider.dxm.*`)
- Parent/dependency Maven `groupId` `org.jahia.modules`

## Verification
- ✅ 11 unit tests pass (JDK17 build)
- ✅ Full Cypress E2E **20/20 pass** on the deployed bundle (mailpit; 01 16/16, 02-Permissions 4/4)