### PR TITLE
chore(deps): bump js-yaml to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "fast-uri": "^3.1.2",
     "ip-address": "^10.1.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "normalize-package-data": "^7.0.0",
     "serialize-javascript": "^7.0.5",
     "tar": "^7.5.16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3461,10 +3461,10 @@ jest-worker@^27.4.5:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.1.0, js-yaml@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
-  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.0.tgz#d1900572a7f7cf0b5f540c83673e60bad3436592"
+  integrity sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Version-update sweep: bumps the `js-yaml` resolution to 4.3.0 (build tooling).

**Test plan:** `mvn clean install` (Java 17) green; Cypress **20/20 pass**. (An initial run had a one-off flake on the 'shows the save button' UI spec — a Module-Federation shared-module load race unrelated to js-yaml; confirmed via a clean-main baseline that also passed 20/20, and a re-run passed.)